### PR TITLE
Feature 1636 - Add 0.9 to supported versions list

### DIFF
--- a/lib/bigbluebutton_api.rb
+++ b/lib/bigbluebutton_api.rb
@@ -68,7 +68,8 @@ module BigBlueButton
     # salt::      Secret salt for this server
     # version::   API version e.g. 0.81
     def initialize(url, salt, version='0.81', debug=false)
-      @supported_versions = ['0.8', '0.81']
+      # TODO check the default version parameter.
+      @supported_versions = ['0.8', '0.81', '0.9']
       @url = url
       @salt = salt
       @debug = debug


### PR DESCRIPTION
I think this is the only thing that needed to be done here.

Other changes are in mconf/bigbluebutton_rails#26 and mconf/mconf-web#118.