### PR TITLE
Bug 1686 - Automatically set the version number

### DIFF
--- a/lib/bigbluebutton_api.rb
+++ b/lib/bigbluebutton_api.rb
@@ -67,7 +67,7 @@ module BigBlueButton
     # url::       URL to a BigBlueButton server (e.g. http://demo.bigbluebutton.org/bigbluebutton/api)
     # salt::      Secret salt for this server
     # version::   API version e.g. 0.81
-    def initialize(url, salt, version='0.9', debug=false)
+    def initialize(url, salt, version=nil, debug=false)
       @supported_versions = ['0.8', '0.81', '0.9']
       @url = url
       @salt = salt

--- a/spec/bigbluebutton_api_spec.rb
+++ b/spec/bigbluebutton_api_spec.rb
@@ -39,6 +39,9 @@ describe BigBlueButton::BigBlueButtonApi do
       end
 
       context "current supported versions" do
+        before {
+          BigBlueButton::BigBlueButtonApi.any_instance.should_receive(:get_api_version).and_return("0.9")
+        }
         subject { BigBlueButton::BigBlueButtonApi.new(url, salt) }
         it { subject.supported_versions.should == ["0.8", "0.81", "0.9"] }
       end


### PR DESCRIPTION
The only thing needed here was to change the default value for the `version` parameter.
The code to fetch the version from the server in case it's not provided was already there.