### PR TITLE
Exception should not be used for CustomErrors, replacing it with StandardError

### DIFF
--- a/lib/bigbluebutton_exception.rb
+++ b/lib/bigbluebutton_exception.rb
@@ -1,6 +1,6 @@
 module BigBlueButton
 
-  class BigBlueButtonException < Exception
+  class BigBlueButtonException < StandardError
     attr_accessor :key
 
     def to_s


### PR DESCRIPTION
Please don't use Exception for application errors, it can't be rescued in a normal catch block... 
See here for best practices: https://www.honeybadger.io/blog/ruby-exception-vs-standarderror-whats-the-difference/