### PR TITLE
ELOSP-441 Added keys to every BigBlueButtonException

### DIFF
--- a/lib/bigbluebutton_api.rb
+++ b/lib/bigbluebutton_api.rb
@@ -760,10 +760,14 @@ module BigBlueButton
         puts "BigBlueButtonAPI: URL response = #{response.body}" if @debug
 
       rescue TimeoutError => error
-        raise BigBlueButtonException.new("Timeout error. Your server is probably down: \"#{@url}\". Error: #{error}")
+        exception = BigBlueButtonException.new("Timeout error. Your server is probably down: \"#{@url}\". Error: #{error}")
+        exception.key = 'TimeoutError'
+        raise exception
 
       rescue Exception => error
-        raise BigBlueButtonException.new("Connection error. Your URL is probably incorrect: \"#{@url}\". Error: #{error}")
+        exception = BigBlueButtonException.new("Connection error. Your URL is probably incorrect: \"#{@url}\". Error: #{error}")
+        exception.key = 'IncorrectUrlError'
+        raise exception
       end
 
       response
@@ -779,7 +783,9 @@ module BigBlueButton
 
       # we don't allow older versions than the one supported, use an old version of the gem for that
       if Gem::Version.new(version) < Gem::Version.new(@supported_versions[0])
-        raise BigBlueButtonException.new("BigBlueButton error: Invalid API version #{version}. Supported versions: #{@supported_versions.join(', ')}")
+        exception = BigBlueButtonException.new("BigBlueButton error: Invalid API version #{version}. Supported versions: #{@supported_versions.join(', ')}")
+        exception.key = 'APIVersionError'
+        raise exception
 
       # allow newer versions by using the newest one we support
       elsif Gem::Version.new(version) > Gem::Version.new(@supported_versions.last)

--- a/lib/bigbluebutton_config_layout.rb
+++ b/lib/bigbluebutton_config_layout.rb
@@ -29,7 +29,9 @@ module BigBlueButton
       begin
         @xml = XmlSimple.xml_in(xml, opts)
       rescue Exception => e
-        raise BigBlueButton::BigBlueButtonException.new("Error parsing the layouts XML. Error: #{e.message}")
+        exception = BigBlueButton::BigBlueButtonException.new("Error parsing the layouts XML. Error: #{e.message}")
+        exception.key = 'XMLParsingError'
+        raise exception
       end
     end
 

--- a/lib/bigbluebutton_config_xml.rb
+++ b/lib/bigbluebutton_config_xml.rb
@@ -33,7 +33,9 @@ module BigBlueButton
           @xml = XmlSimple.xml_in(xml, opts)
           @original_string = self.as_string.clone
         rescue Exception => e
-          raise BigBlueButton::BigBlueButtonException.new("Error parsing the config XML. Error: #{e.message}")
+          exception = BigBlueButton::BigBlueButtonException.new("Error parsing the config XML. Error: #{e.message}")
+          exception.key = 'XMLParsingError'
+          raise exception
         end
       end
     end

--- a/lib/bigbluebutton_hash_to_xml.rb
+++ b/lib/bigbluebutton_hash_to_xml.rb
@@ -10,7 +10,9 @@ module BigBlueButton
           hash = XmlSimple.xml_in(xml_io, opts)
           return symbolize_keys(hash)
         rescue Exception => e
-          raise BigBlueButtonException.new("Impossible to convert XML to hash. Error: #{e.message}")
+          exception = BigBlueButtonException.new("Impossible to convert XML to hash. Error: #{e.message}")
+          exception.key = 'XMLConversionError'  
+          raise exception
         end
       end
 


### PR DESCRIPTION
These are the same changes made to RNP, adapted to the branch Elos uses.

With these keys we can display a better error flash on the bigbluebutton_rails gem.