### PR TITLE
GEMAPIRUBY-4 Add 'get_all_meetings' method

### DIFF
--- a/examples/overall_example.rb
+++ b/examples/overall_example.rb
@@ -32,6 +32,14 @@ begin
 
   puts
   puts "---------------------------------------------------"
+  response = @api.get_all_meetings
+  puts "Existent meetings in your server:"
+  response[:meetings].each do |m|
+    puts "  " + m[:meetingID] + ": " + m.inspect
+  end
+
+  puts
+  puts "---------------------------------------------------"
   response = @api.get_recordings
   puts "Existent recordings in your server:"
   response[:recordings].each do |m|

--- a/examples/overall_example.rb
+++ b/examples/overall_example.rb
@@ -27,7 +27,7 @@ begin
   response = @api.get_meetings
   puts "Existent meetings in your server:"
   response[:meetings].each do |m|
-    puts "  " + m[:meetingID] + ": " + m.inspect
+    puts "  #{m[:meetingID]}: #{m.inspect}"
   end
 
   puts
@@ -35,15 +35,15 @@ begin
   response = @api.get_all_meetings
   puts "Existent meetings in your server:"
   response[:meetings].each do |m|
-    puts "  " + m[:meetingID] + ": " + m.inspect
+    puts "  #{m[:meetingID]}: #{m.inspect}"
   end
 
   puts
   puts "---------------------------------------------------"
   response = @api.get_recordings
   puts "Existent recordings in your server:"
-  response[:recordings].each do |m|
-    puts "  " + m[:recordID] + ": " + m.inspect
+  response[:recordings].each do |r|
+    puts "  #{r[:recordID]}: #{r.inspect}"
   end
 
   puts

--- a/features/step_definitions/check_status_steps.rb
+++ b/features/step_definitions/check_status_steps.rb
@@ -12,6 +12,10 @@ When /^calling the method get_meetings$/ do
   @req.response = @api.get_meetings
 end
 
+When /^calling the method get_all_meetings$/ do
+  @req.response = @api.get_all_meetings
+end
+
 When /^calling the method get_meeting_info$/ do
   @req.response = @api.get_meeting_info(@req.id, @req.mod_pass)
 end

--- a/features/step_definitions/recordings_steps.rb
+++ b/features/step_definitions/recordings_steps.rb
@@ -39,5 +39,5 @@ end
 
 When /^the user calls the get_all_meetings method and include recordings$/ do
   @req.method = :get_all_meetings
-  @req.response = @api.get_all_meetings( { :includeRecordings=>true } )
+  @req.response = @api.get_all_meetings( { includeRecordings: true } )
 end

--- a/features/step_definitions/recordings_steps.rb
+++ b/features/step_definitions/recordings_steps.rb
@@ -36,3 +36,8 @@ When /^the user calls the get_recordings method$/ do
   @req.method = :get_recordings
   @req.response = @api.get_recordings
 end
+
+When /^the user calls the get_all_meetings method and include recordings$/ do
+  @req.method = :get_all_meetings
+  @req.response = @api.get_all_meetings( { :includeRecordings=>true } )
+end

--- a/lib/bigbluebutton_api.rb
+++ b/lib/bigbluebutton_api.rb
@@ -462,7 +462,7 @@ module BigBlueButton
     #                          :description => "List of recordings",
     #                          :activity => "e66e88a3" },
     #           :playback => {
-    #             :format => [
+    #             :format => [ # if there is only one format, this will be a hash instead
     #               { :type => "slides",
     #                 :url => "http://test-install.blindsidenetworks.com/playback/slides/playback.html?meetingId=125468758b24fa27551e7a065849dda3ce65dd32-1329872486268",
     #                 :length => 64

--- a/lib/bigbluebutton_api.rb
+++ b/lib/bigbluebutton_api.rb
@@ -489,21 +489,14 @@ module BigBlueButton
     #          :listenerCount => 0,
     #          :videoCount => 0 
     #         }
-    #         :recording => {
-    #           :recordID => "1254kakap98sd09jk2lk2-1329872486234",
-    #           :meetingID => "8f21cc63",
-    #           :name => "8f21cc63",
+    #         :recording => { # meeting without recording
+    #           :recordID => "{}",
+    #           :meetingID => "{}",
+    #           :name => "{}",
     #           :published => false,
-    #           :startTime => #<DateTime: 2011-11-18T12:10:23+00:00 (212188378223/86400,0/1,2299161)>,
-    #           :endTime => #<DateTime: 2011-11-18T12:12:25+00:00 (42437675669/17280,0/1,2299161)>,
+    #           :startTime => nil,
+    #           :endTime => nil,
     #           :metadata => {},
-    #           :playback => {
-    #             :format => { # notice that this is now a hash, not an array
-    #               :type => "slides",
-    #               :url => "http://test-install.blindsidenetworks.com/playback/slides/playback.html?meetingId=1254kakap98sd09jk2lk2-1329872486234",
-    #               :length => 64
-    #             }
-    #           }
     #         }
     #       }
     #     ],


### PR DESCRIPTION
Adds the `get_all_meetings` API call, which accepts a hash of options. Without additional parameters, it returns the same as `get_meetings`.

**Important: This is currently not part of the official BigBlueButton API.**

Its main purpose is to allow custom APIs to implement additional parameters (e.g. to append the recordings associated with the meetings in the response) keeping the original `get_meetings` call untouched.

Some parameters implemented on our extension of the API:
- `meetingID` (string): filters meetings by meetingID; supports wildcart filtering when `meetingIDWildcard=true`.
- `includeRecordings` (boolean): appends the recordings associated with the meetings in the response.
- `state` (string): filters meetings by state.
- `limit` and `offset` (integer): support for pagination.

Method signature:
`get_all_meetings(options={})`

Usage example:

```
get_all_meetings()
// Response:
{
  :returncode => true,
  :meetings => [
    { :meetingID => "e66e88a3",
    :meetingName => "e66e88a3",
    :createTime => 1389466124414,
    ...
    },
    { :meetingID => "e66e88a4",
    :meetingName => "e66e88a4",
    :createTime => 1389466124999,
    ...
    }
  ],
  :messageKey => "",
  :message => ""
}
```