### PR TITLE
Added SHA512 support

### DIFF
--- a/lib/bigbluebutton_api.rb
+++ b/lib/bigbluebutton_api.rb
@@ -67,7 +67,7 @@ module BigBlueButton
     # secret::    Shared secret for this server
     # version::   API version e.g. 0.81
     # logger::    Logger object to log actions (so apps can use their own loggers)
-    # algorithm:: Define which algorithm to use
+    # algorithm:: Define which algorithm to use [sha1, sha256, sha512]
     def initialize(url, secret, version=nil, logger=nil, algorithm="sha1")
       @supported_versions = ['0.8', '0.81', '0.9', '1.0']
       @url = url.chomp('/')

--- a/lib/bigbluebutton_api.rb
+++ b/lib/bigbluebutton_api.rb
@@ -67,15 +67,15 @@ module BigBlueButton
     # secret::    Shared secret for this server
     # version::   API version e.g. 0.81
     # logger::    Logger object to log actions (so apps can use their own loggers)
-    # sha256::    Flag to use sha256 when hashing url contents for checksum
-    def initialize(url, secret, version=nil, logger=nil, sha256=false)
+    # algorithm:: Define which algorithm to use
+    def initialize(url, secret, version=nil, logger=nil, algorithm="sha1")
       @supported_versions = ['0.8', '0.81', '0.9', '1.0']
       @url = url.chomp('/')
       @secret = secret
       @timeout = 10         # default timeout for api requests
       @request_headers = {} # http headers sent in all requests
       @logger = logger
-      @sha256 = sha256
+      @algorithm = algorithm
       # If logger is not informed, it defaults to STDOUT with INFO level
       if logger.nil?
         @logger = Logger.new(STDOUT)
@@ -604,7 +604,7 @@ module BigBlueButton
       # checksum calc
       checksum_param = params_string + @secret
       checksum_param = method.to_s + checksum_param
-      checksum = @sha256 ? Digest::SHA256.hexdigest(checksum_param) : Digest::SHA1.hexdigest(checksum_param)
+      checksum = calculate_checksum(checksum_param)
 
       url = "#{@url}/#{method}?"
       url += "#{params_string}&" unless params_string.empty?
@@ -721,5 +721,15 @@ module BigBlueButton
       end
     end
 
+    def calculate_checksum(checksum_param)
+      case @algorithm
+      when "sha512"
+        Digest::SHA512.hexdigest(checksum_param)
+      when "sha2", "sha256", true
+        Digest::SHA256.hexdigest(checksum_param)
+      else
+        Digest::SHA1.hexdigest(checksum_param)
+      end
+    end
   end
 end

--- a/lib/bigbluebutton_api.rb
+++ b/lib/bigbluebutton_api.rb
@@ -725,7 +725,7 @@ module BigBlueButton
       case @algorithm
       when "sha512"
         Digest::SHA512.hexdigest(checksum_param)
-      when "sha2", "sha256", true
+      when "sha2", "sha256", true # checks true for legacy support
         Digest::SHA256.hexdigest(checksum_param)
       else
         Digest::SHA1.hexdigest(checksum_param)

--- a/spec/bigbluebutton_api_spec.rb
+++ b/spec/bigbluebutton_api_spec.rb
@@ -465,31 +465,55 @@ describe BigBlueButton::BigBlueButtonApi do
         end
 
         context "includes the checksum" do
-          context "when @sha256 is false or nil" do
-            let(:params) { { param1: "value1", param2: "value2" } }
-            let(:checksum) {
-              # the hash can be sorted differently depending on the ruby version
-              if params.map{ |k, v| k }.join =~ /^param1/
-                "67882ae54f49600f56f358c10d24697ef7d8c6b2"
-              else
-                "85a54e28e4ec18bfdcb214a73f74d35b09a84176"
-              end
-            }
+          let(:method) { "join" }
+          let(:params) { { param1: "value1", param2: "value2" } }
+          let(:params_string) { params.map{ |k,v| "#{k}=" + URI.encode_www_form_component(v.to_s) unless k.nil? || v.nil? }.join("&") }
+          let(:checksum_param) { method.to_s + params_string + secret }
+
+          context "when @algorithm is false or nil" do
+            let(:checksum) { Digest::SHA1.hexdigest(checksum_param ) }
+
             subject { api.get_url(:join, params)[0] }
             it('uses SHA1') { subject.should match(/checksum=#{checksum}$/) }
           end
 
-          context "when @sha256 flag is true" do
+          context "when @algorithm is is set to 'sha1'" do
+            let(:api) { BigBlueButton::BigBlueButtonApi.new(url, secret, version, logger, "sha1") }
+            let(:checksum) { Digest::SHA1.hexdigest(checksum_param ) }
+
+            subject { api.get_url(:join, params)[0] }
+            it('uses SHA1') { subject.should match(/checksum=#{checksum}$/) }
+          end
+
+          context "when @algorithm flag is set to 'sha2'" do
+            let(:api) { BigBlueButton::BigBlueButtonApi.new(url, secret, version, logger, "sha2") }
+            let(:checksum) { Digest::SHA256.hexdigest(checksum_param ) }
+
+            subject { api.get_url(:join, params)[0] }
+            it('uses SHA256') { subject.should match(/checksum=#{checksum}$/) }
+          end
+
+          context "when @algorithm flag is set to 'sha256'" do
+            let(:api) { BigBlueButton::BigBlueButtonApi.new(url, secret, version, logger, "sha256") }
+            let(:checksum) { Digest::SHA256.hexdigest(checksum_param ) }
+
+            subject { api.get_url(:join, params)[0] }
+            it('uses SHA256') { subject.should match(/checksum=#{checksum}$/) }
+          end
+
+          context "when @algorithm flag is set to 'sha512'" do
+            let(:api) { BigBlueButton::BigBlueButtonApi.new(url, secret, version, logger, "sha512") }
+            let(:checksum) { Digest::SHA512.hexdigest(checksum_param ) }
+
+            subject { api.get_url(:join, params)[0] }
+            it('uses SHA256') { subject.should match(/checksum=#{checksum}$/) }
+          end
+
+          # Ensure legacy support
+          context "when @algorithm flag is true" do
             let(:api) { BigBlueButton::BigBlueButtonApi.new(url, secret, version, logger, true) }
-            let(:params) { { param1: "value1", param2: "value2" } }
-            let(:checksum) {
-              # the hash can be sorted differently depending on the ruby version
-              if params.map{ |k,v| k }.join =~ /^param1/
-                "0e7b1611809fad890a114dddae1a37fecf14c28971afc10ee3eac432da5b8b41"
-              else
-                "21bf2d24c27251c4b2b2f0d5dd4b966a2f16fbfc7882e102b44c6d67f728f0c8"
-              end
-            }
+            let(:checksum) { Digest::SHA256.hexdigest(checksum_param ) }
+
             subject { api.get_url(:join, params)[0] }
             it('uses SHA256') { subject.should match(/checksum=#{checksum}$/) }
           end


### PR DESCRIPTION
- Replaces the current `sha256` param with a more flexible `algorithm` param
- Keeps legacy support by converting `false -> sha1` and `true -> sha2`